### PR TITLE
[BE] 채팅기능 초기 구현

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,8 +25,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-test'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.2' 
-    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2' 
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
@@ -36,6 +39,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.modelmapper:modelmapper:2.3.8'
+    implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+
 }
 
 tasks.named('test') {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,6 +16,13 @@ configurations {
 
 repositories {
     mavenCentral()
+    maven { url "https://repo.spring.io/milestone" }        // for Query DSL
+    maven { url "https://repo.spring.io/snapshot" }         // for Query DSL
+}
+
+clean {
+    delete file('src/main/generated') // 인텔리제이 Annotation processor 생성물 생성위치
+    delete file('out') // 인텔리제이 Annotation processor 생성물 생성위치
 }
 
 dependencies {
@@ -41,8 +48,31 @@ dependencies {
     implementation 'org.modelmapper:modelmapper:2.3.8'
     implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 
+    implementation("com.querydsl:querydsl-core")
+    implementation("com.querydsl:querydsl-jpa")
+    annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa")
+    // querydsl JPAAnnotationProcessor 사용 지정
+    testImplementation("com.querydsl:querydsl-jpa")
+    testAnnotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    implementation 'org.webjars.bower:bootstrap:4.3.1'
+    implementation 'org.webjars.bower:vue:2.5.16'
+    implementation 'org.webjars.bower:axios:0.17.1'
+    implementation 'org.webjars:sockjs-client:1.1.2'
+    implementation 'org.webjars:stomp-websocket:2.3.3-1'
 }
 
-tasks.named('test') {
+def generated = 'src/main/generated'
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+tasks.withType(JavaCompile) {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
+
+test {
     useJUnitPlatform()
 }

--- a/server/src/main/java/com/ttukttak/book/entity/Book.java
+++ b/server/src/main/java/com/ttukttak/book/entity/Book.java
@@ -1,0 +1,43 @@
+package com.ttukttak.book.entity;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.oauth.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Book implements Serializable {
+	private static final long serialVersionUID = 1L;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "owner_id")
+	private User owner;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "book")
+	private List<ChatRoom> chatRooms;
+
+	@Builder
+	public Book(Long id, User owner) {
+		this.id = id;
+		this.owner = owner;
+	}
+}

--- a/server/src/main/java/com/ttukttak/book/repository/BookRepository.java
+++ b/server/src/main/java/com/ttukttak/book/repository/BookRepository.java
@@ -1,0 +1,8 @@
+package com.ttukttak.book.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ttukttak.book.entity.Book;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/server/src/main/java/com/ttukttak/chat/config/EmbeddedRedisConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/EmbeddedRedisConfig.java
@@ -1,0 +1,33 @@
+package com.ttukttak.chat.config;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import redis.embedded.RedisServer;
+
+@Profile("default")
+@Configuration
+public class EmbeddedRedisConfig {
+
+	@Value("${spring.redis.port}")
+	private int redisPort;
+
+	private RedisServer redisServer;
+
+	@PostConstruct
+	public void redisServer() {
+		redisServer = new RedisServer(redisPort);
+		redisServer.start();
+	}
+
+	@PreDestroy
+	public void stopRedis() {
+		if (redisServer != null) {
+			redisServer.stop();
+		}
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/config/RedisConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/RedisConfig.java
@@ -1,0 +1,38 @@
+package com.ttukttak.chat.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedisConfig {
+
+	/**
+	 * redis pub/sub 메시지를 처리하는 listener 설정
+	 */
+	@Bean
+	public RedisMessageListenerContainer redisMessageListener(RedisConnectionFactory connectionFactory) {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		return container;
+	}
+
+	/**
+	 * 어플리케이션에서 사용할 redisTemplate 설정
+	 */
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(connectionFactory);
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+		return redisTemplate;
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/config/WebSocketConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.ttukttak.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		config.enableSimpleBroker("/sub");
+		config.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws-stomp").setAllowedOrigins("*")
+			.withSockJS();
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatController.java
@@ -1,0 +1,28 @@
+package com.ttukttak.chat.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.service.ChatRoomService;
+import com.ttukttak.chat.service.RedisPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Controller
+public class ChatController {
+
+	private final RedisPublisher redisPublisher;
+	private final ChatRoomService chatRoomService;
+
+	/**
+	 * websocket "/pub/chat/message"로 들어오는 메시징을 처리한다.
+	 */
+	@MessageMapping("/chat/message")
+	public void message(ChatMessageDto message) {
+		// Websocket에 발행된 메시지를 redis로 발행한다(publish)
+		System.out.println("redis 전송 : " + message);
+		redisPublisher.publish(chatRoomService.getTopic(message.getRoomId()), message);
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
@@ -1,0 +1,25 @@
+package com.ttukttak.chat.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.service.ChatMessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/message")
+public class ChatMessageController {
+	private final ChatMessageService chatMessageService;
+
+	@GetMapping("/{roomId}")
+	public List<ChatMessageDto> findAllChats(@PathVariable Long roomId) {
+		return chatMessageService.getChatMessages(roomId);
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
@@ -1,0 +1,51 @@
+package com.ttukttak.chat.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.ttukttak.chat.dto.ChatRoomCard;
+import com.ttukttak.chat.dto.ChatRoomInfo;
+import com.ttukttak.chat.dto.ChatRoomRequest;
+import com.ttukttak.chat.service.ChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/chat")
+public class ChatRoomController {
+
+	private final ChatRoomService chatRoomService;
+
+	// 모든 채팅방 목록 반환
+	@GetMapping("/rooms/{userId}")
+	@ResponseBody
+	public ResponseEntity<List<ChatRoomCard>> getRooms(@PathVariable Long userId) {
+		List<ChatRoomCard> chatRooms = chatRoomService.getRoomList(userId);
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(chatRooms);
+	}
+
+	// 채팅방 생성
+	@PostMapping("/room")
+	@ResponseBody
+	public ResponseEntity<ChatRoomInfo> createRoom(@RequestParam ChatRoomRequest request) {
+		ChatRoomInfo chatRoomInfo = chatRoomService.createChatRoom(request);
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(chatRoomInfo);
+	}
+
+}

--- a/server/src/main/java/com/ttukttak/chat/controller/WebSocketController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/WebSocketController.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Controller
-public class ChatController {
+public class WebSocketController {
 
 	private final RedisPublisher redisPublisher;
 	private final ChatRoomService chatRoomService;

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
@@ -1,0 +1,39 @@
+package com.ttukttak.chat.dto;
+
+import java.time.LocalDateTime;
+
+import com.ttukttak.chat.entity.ChatMessage;
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.oauth.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class ChatMessageDto {
+	private Long userId;
+	private Long roomId;
+	private String message;
+	private MessageType messageType;
+
+	private LocalDateTime createdDate;
+
+	public ChatMessage toEntity() {
+		ChatRoom chatRoom = ChatRoom.builder().id(roomId).build();
+		User user = User.builder().id(userId).build();
+
+		return ChatMessage.builder()
+			.chatRoom(chatRoom)
+			.user(user)
+			.message(message)
+			.messageType(messageType)
+			.build();
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
@@ -18,12 +18,13 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class ChatMessageDto {
+	private Long id;
 	private Long userId;
 	private Long roomId;
 	private String message;
 	private MessageType messageType;
 
-	private LocalDateTime createdDate;
+	private LocalDateTime sendedAt;
 
 	public ChatMessage toEntity() {
 		ChatRoom chatRoom = ChatRoom.builder().id(roomId).build();
@@ -34,6 +35,7 @@ public class ChatMessageDto {
 			.user(user)
 			.message(message)
 			.messageType(messageType)
+			.sendedAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
@@ -1,0 +1,20 @@
+package com.ttukttak.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChatRoomCard {
+	private Long roomId;
+	private Long bookId;
+	private ChatUser other;
+	private LastMessage lastMessage;
+
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
@@ -1,0 +1,20 @@
+package com.ttukttak.chat.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChatRoomInfo {
+
+	private Long roomId;
+	private List<ChatUser> users;
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomRequest.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomRequest.java
@@ -9,8 +9,8 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateChatRequest {
-	private Long hostId;
-	private Long guestId;
+public class ChatRoomRequest {
+	private Long bookId;
+	private Long userId;
 
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatUser.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatUser.java
@@ -1,0 +1,17 @@
+package com.ttukttak.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChatUser {
+	private Long id;
+	private String name;
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/CreateChatRequest.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/CreateChatRequest.java
@@ -1,0 +1,16 @@
+package com.ttukttak.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateChatRequest {
+	private Long hostId;
+	private Long guestId;
+
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/LastMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/LastMessage.java
@@ -1,0 +1,9 @@
+package com.ttukttak.chat.dto;
+
+import java.time.LocalDateTime;
+
+public class LastMessage {
+	private String message;
+	private MessageType messageType;
+	private LocalDateTime sendedAt;
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/MessageType.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/MessageType.java
@@ -1,0 +1,5 @@
+package com.ttukttak.chat.dto;
+
+public enum MessageType {
+	TEXT, FILE
+}

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
@@ -1,0 +1,58 @@
+package com.ttukttak.chat.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.annotations.ColumnDefault;
+
+import com.ttukttak.chat.dto.MessageType;
+import com.ttukttak.oauth.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class ChatMessage implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "room_id")
+	private ChatRoom chatRoom;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@NotNull
+	private String message;
+
+	@Enumerated(EnumType.STRING)
+	@ColumnDefault("'TEXT'")
+	private MessageType messageType;
+
+	@Builder
+	public ChatMessage(ChatRoom chatRoom, User user, String message,
+		MessageType messageType) {
+		this.chatRoom = chatRoom;
+		this.user = user;
+		this.message = message;
+		this.messageType = messageType;
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
@@ -1,6 +1,7 @@
 package com.ttukttak.chat.entity;
 
 import java.io.Serializable;
+import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -47,12 +48,16 @@ public class ChatMessage implements Serializable {
 	@ColumnDefault("'TEXT'")
 	private MessageType messageType;
 
+	private LocalDateTime sendedAt;
+
 	@Builder
-	public ChatMessage(ChatRoom chatRoom, User user, String message,
-		MessageType messageType) {
+	public ChatMessage(Long id, ChatRoom chatRoom, User user, String message, MessageType messageType,
+		LocalDateTime sendedAt) {
+		this.id = id;
 		this.chatRoom = chatRoom;
 		this.user = user;
 		this.message = message;
 		this.messageType = messageType;
+		this.sendedAt = sendedAt;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
@@ -1,19 +1,21 @@
 package com.ttukttak.chat.entity;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 
+import com.ttukttak.book.entity.Book;
 import com.ttukttak.common.BaseTimeEntity;
-import com.ttukttak.oauth.entity.User;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -29,30 +31,24 @@ public class ChatRoom extends BaseTimeEntity implements Serializable {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	//TODO: 책 구현되면 my_book_id 사용
-	// Book book
-	// @OneToOne
-	// @JoinColumn(name = "my_book_id")
-	// private MyBook message;
+	@ManyToOne
+	@JoinColumn(name = "book_id")
+	private Book book;
 
-	@OneToOne
-	@JoinColumn(name = "host_id")
-	private User host;
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom")
+	private List<ChatMessage> messages = new ArrayList<>();
 
-	@OneToOne
-	@JoinColumn(name = "guest_id")
-	private User guest;
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<LastCheckedMessage> lastCheckedMessages = new ArrayList<>();
 
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom", orphanRemoval = true)
-	private List<ChatMessage> messages;
-
-	@OneToMany(fetch = FetchType.LAZY, mappedBy = "room", orphanRemoval = true)
-	private List<LastCheckedMessage> lastCheckedMessage;
+	public void addLastCheckedMessage(LastCheckedMessage lastCheckedMessage) {
+		lastCheckedMessages.add(lastCheckedMessage);
+		lastCheckedMessage.changeRoom(this);
+	}
 
 	@Builder
-	public ChatRoom(Long id, User host, User guest) {
+	public ChatRoom(Long id, Book book) {
 		this.id = id;
-		this.host = host;
-		this.guest = guest;
+		this.book = book;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
@@ -1,0 +1,58 @@
+package com.ttukttak.chat.entity;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+
+import com.ttukttak.common.BaseTimeEntity;
+import com.ttukttak.oauth.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ChatRoom extends BaseTimeEntity implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	//TODO: 책 구현되면 my_book_id 사용
+	// Book book
+	// @OneToOne
+	// @JoinColumn(name = "my_book_id")
+	// private MyBook message;
+
+	@OneToOne
+	@JoinColumn(name = "host_id")
+	private User host;
+
+	@OneToOne
+	@JoinColumn(name = "guest_id")
+	private User guest;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom", orphanRemoval = true)
+	private List<ChatMessage> messages;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "room", orphanRemoval = true)
+	private List<LastCheckedMessage> lastCheckedMessage;
+
+	@Builder
+	public ChatRoom(Long id, User host, User guest) {
+		this.id = id;
+		this.host = host;
+		this.guest = guest;
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
@@ -36,12 +36,16 @@ public class LastCheckedMessage implements Serializable {
 
 	@OneToOne
 	@JoinColumn(name = "message_id")
-	private ChatMessage message;
+	private ChatMessage chatMessage;
+
+	public void changeRoom(ChatRoom room) {
+		this.room = room;
+	}
 
 	@Builder
-	public LastCheckedMessage(User user, ChatRoom room, ChatMessage message) {
+	public LastCheckedMessage(User user, ChatRoom room, ChatMessage chatMessage) {
 		this.user = user;
 		this.room = room;
-		this.message = message;
+		this.chatMessage = chatMessage;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
@@ -1,0 +1,47 @@
+package com.ttukttak.chat.entity;
+
+import java.io.Serializable;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+
+import com.ttukttak.oauth.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class LastCheckedMessage implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne
+	@JoinColumn(name = "room_id")
+	private ChatRoom room;
+
+	@OneToOne
+	@JoinColumn(name = "message_id")
+	private ChatMessage message;
+
+	@Builder
+	public LastCheckedMessage(User user, ChatRoom room, ChatMessage message) {
+		this.user = user;
+		this.room = room;
+		this.message = message;
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
@@ -1,8 +1,11 @@
 package com.ttukttak.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ttukttak.chat.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+	List<ChatMessage> findAllByRoomId(Long roomId);
 }

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,8 @@
+package com.ttukttak.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ttukttak.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.ttukttak.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ttukttak.chat.entity.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepositoryCustom.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepositoryCustom.java
@@ -1,0 +1,29 @@
+package com.ttukttak.chat.repository;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.chat.entity.QChatRoom;
+import com.ttukttak.chat.entity.QLastCheckedMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryCustom {
+
+	private final JPAQueryFactory query;
+
+	public List<ChatRoom> findAllChatRoomByUserId(Long userId) {
+		QChatRoom cr = new QChatRoom("cr");
+		QLastCheckedMessage lcm = new QLastCheckedMessage("lcm");
+
+		return query.selectFrom(cr)
+			.where(lcm.user.id.eq(userId), lcm.room.id.eq(cr.id))
+			.fetch();
+	}
+
+}

--- a/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
@@ -1,0 +1,9 @@
+package com.ttukttak.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ttukttak.chat.entity.LastCheckedMessage;
+
+public interface LastCheckedMessageRepository extends JpaRepository<LastCheckedMessage, Long> {
+	// Optional<LastCheckedMessage> findById(Long id);
+}

--- a/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ttukttak.chat.entity.LastCheckedMessage;
 
 public interface LastCheckedMessageRepository extends JpaRepository<LastCheckedMessage, Long> {
-	// Optional<LastCheckedMessage> findById(Long id);
 }

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
@@ -1,0 +1,11 @@
+package com.ttukttak.chat.service;
+
+import java.util.List;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+
+public interface ChatMessageService {
+	void saveChatMessage(ChatMessageDto chatMessageDto);
+
+	List<ChatMessageDto> getChatMessages(Long roomId);
+}

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
@@ -1,0 +1,33 @@
+package com.ttukttak.chat.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.repository.ChatMessageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class ChatMessageServiceImpl implements ChatMessageService {
+	private final ModelMapper modelMapper;
+	private final ChatMessageRepository chatMessageRepository;
+
+	@Override
+	public void saveChatMessage(ChatMessageDto chatMessageDto) {
+		chatMessageRepository.save(chatMessageDto.toEntity());
+	}
+
+	@Override
+	public List<ChatMessageDto> getChatMessages(Long roomId) {
+
+		return chatMessageRepository.findAllByRoomId(roomId)
+			.stream()
+			.map(chatMessage -> modelMapper.map(chatMessage, ChatMessageDto.class))
+			.collect(Collectors.toList());
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/service/ChatRoomService.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatRoomService.java
@@ -1,0 +1,27 @@
+package com.ttukttak.chat.service;
+
+import java.util.List;
+
+import org.springframework.data.redis.listener.ChannelTopic;
+
+import com.ttukttak.chat.dto.ChatRoomCard;
+import com.ttukttak.chat.dto.ChatRoomInfo;
+import com.ttukttak.chat.dto.ChatRoomRequest;
+
+public interface ChatRoomService {
+	List<ChatRoomCard> getRoomList(Long userId);
+
+	ChatRoomInfo findRoomById(Long id);
+
+	/**
+	 * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
+	 */
+	ChatRoomInfo createChatRoom(ChatRoomRequest request);
+
+	/**
+	 * 채팅방 입장 : redis에 topic을 만들고 pub/sub 통신을 하기 위해 리스너를 설정한다.
+	 */
+	void enterChatRoom(Long roomId);
+
+	ChannelTopic getTopic(Long roomId);
+}

--- a/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
@@ -1,0 +1,120 @@
+package com.ttukttak.chat.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+import com.ttukttak.book.entity.Book;
+import com.ttukttak.book.repository.BookRepository;
+import com.ttukttak.chat.dto.ChatRoomCard;
+import com.ttukttak.chat.dto.ChatRoomInfo;
+import com.ttukttak.chat.dto.ChatRoomRequest;
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.chat.entity.LastCheckedMessage;
+import com.ttukttak.chat.repository.ChatRoomRepository;
+import com.ttukttak.chat.repository.ChatRoomRepositoryCustom;
+import com.ttukttak.oauth.entity.User;
+import com.ttukttak.oauth.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatRoomServiceImpl implements ChatRoomService {
+	private final ModelMapper modelMapper;
+	private final ChatRoomRepository chatRoomRepository;
+
+	private final ChatRoomRepositoryCustom chatRoomRepositoryCustom;
+	private final BookRepository bookRepository;
+	private final UserRepository userRepository;
+
+	// 채팅방(topic)에 발행되는 메시지를 처리할 Listner
+	private final RedisMessageListenerContainer redisMessageListener;
+	// 구독 처리 서비스
+	private final RedisSubscriber redisSubscriber;
+	// Redis
+	private static final String CHAT_ROOMS = "CHAT_ROOM";
+	private final RedisTemplate<String, Object> redisTemplate;
+	private HashOperations<String, Long, ChatRoomInfo> opsHashChatRoom;
+
+	// 채팅방의 대화 메시지를 발행하기 위한 redis topic 정보. 서버별로 채팅방에 매치되는 topic정보를 Map에 넣어 roomId로 찾을수 있도록 한다.
+	private Map<Long, ChannelTopic> topics;
+
+	@PostConstruct
+	private void init() {
+		opsHashChatRoom = redisTemplate.opsForHash();
+		topics = new HashMap<>();
+	}
+
+	@Override
+	public List<ChatRoomCard> getRoomList(Long userId) {
+
+		return chatRoomRepositoryCustom.findAllChatRoomByUserId(userId)
+			.stream()
+			.map(chatRoom -> modelMapper.map(chatRoom, ChatRoomCard.class))
+			.collect(Collectors.toList());
+	}
+
+	public ChatRoomInfo findRoomById(Long id) {
+		return opsHashChatRoom.get(CHAT_ROOMS, id);
+	}
+
+	/**
+	 * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
+	 */
+	public ChatRoomInfo createChatRoom(ChatRoomRequest request) {
+		//TODO: 예외처리 해야함
+		Book book = bookRepository.findById(request.getBookId()).orElse(null);
+
+		User host = book.getOwner();
+		User guest = userRepository.findById(request.getUserId()).orElse(null);
+
+		ChatRoom chatRoom = ChatRoom.builder()
+			.book(book)
+			.build();
+
+		LastCheckedMessage hostLastCheckedMessage = LastCheckedMessage.builder().user(host).build();
+		LastCheckedMessage guestLastCheckedMessage = LastCheckedMessage.builder().user(guest).build();
+
+		chatRoom.addLastCheckedMessage(hostLastCheckedMessage);
+		chatRoom.addLastCheckedMessage(guestLastCheckedMessage);
+
+		chatRoomRepository.save(chatRoom);
+
+		log.info(chatRoom.getId() + " : 생성");
+
+		ChatRoomInfo chatRoomInfo = modelMapper.map(chatRoom, ChatRoomInfo.class);
+
+		opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getId(), chatRoomInfo);
+
+		return chatRoomInfo;
+	}
+
+	/**
+	 * 채팅방 입장 : redis에 topic을 만들고 pub/sub 통신을 하기 위해 리스너를 설정한다.
+	 */
+	public void enterChatRoom(Long roomId) {
+		ChannelTopic topic = topics.get(roomId);
+		if (topic == null) {
+			topic = new ChannelTopic(roomId.toString());
+			redisMessageListener.addMessageListener(redisSubscriber, topic);
+			topics.put(roomId, topic);
+		}
+	}
+
+	public ChannelTopic getTopic(Long roomId) {
+		return topics.get(roomId);
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/service/RedisPublisher.java
+++ b/server/src/main/java/com/ttukttak/chat/service/RedisPublisher.java
@@ -1,0 +1,24 @@
+package com.ttukttak.chat.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class RedisPublisher {
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	/**
+	 * Redis로 메세지 보냄
+	 * @param topic
+	 * @param message
+	 */
+	public void publish(ChannelTopic topic, ChatMessageDto message) {
+		redisTemplate.convertAndSend(topic.getTopic(), message);
+	}
+}

--- a/server/src/main/java/com/ttukttak/chat/service/RedisSubscriber.java
+++ b/server/src/main/java/com/ttukttak/chat/service/RedisSubscriber.java
@@ -1,0 +1,46 @@
+package com.ttukttak.chat.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.repository.ChatMessageRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisSubscriber implements MessageListener {
+	@Autowired
+	private final ChatMessageRepository chatMessageRepository;
+	private final ObjectMapper objectMapper;
+	private final RedisTemplate redisTemplate;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	/**
+	 * Redis에서 메시지가 발행(publish)되면 대기하고 있던 onMessage가 해당 메시지를 받아 처리한다.
+	 */
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		try {
+			// redis에서 발행된 데이터를 받아 deserialize
+			String publishMessage = (String)redisTemplate.getStringSerializer().deserialize(message.getBody());
+			ChatMessageDto roomMessage = objectMapper.readValue(publishMessage, ChatMessageDto.class);
+
+			chatMessageRepository.save(roomMessage.toEntity());
+
+			log.info("redis 수신 : {}", roomMessage);
+			// Websocket 구독자에게 채팅 메시지 Send
+			messagingTemplate.convertAndSend("/sub/chat/room/" + roomMessage.getRoomId(), roomMessage);
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+}

--- a/server/src/main/java/com/ttukttak/common/config/QuerydslConfig.java
+++ b/server/src/main/java/com/ttukttak/common/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.ttukttak.common.config;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/server/src/main/java/com/ttukttak/oauth/entity/User.java
+++ b/server/src/main/java/com/ttukttak/oauth/entity/User.java
@@ -1,60 +1,69 @@
 package com.ttukttak.oauth.entity;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sun.istack.NotNull;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 
 @Getter
 @NoArgsConstructor
 @Entity
 public class User {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Column
-    private String name;
+	@Column
+	private String name;
 
-    @Column(nullable = false)
-    private String email;
+	@Column(nullable = false)
+	private String email;
 
-    @Column
-    private String imageUrl;
+	@Column
+	private String imageUrl;
 
-    @NotNull
-    @JsonIgnore
-    @Enumerated(EnumType.STRING)
-    private AuthProvider provider;
-    
-    @Column
-    @Enumerated(EnumType.STRING)
-    private Role role;
+	@NotNull
+	@JsonIgnore
+	@Enumerated(EnumType.STRING)
+	private AuthProvider provider;
 
-    @Column
-    private String providerId;
-    
-    @Column
-    private String gender;
-    
-    @Column
-    private String age;
+	@Column
+	@Enumerated(EnumType.STRING)
+	private Role role;
 
-    @Builder
-    public User(String name, String email, String imageUrl,Role role, AuthProvider provider, String providerId, String gender, String age) {
-        this.name = name;
-        this.email = email;
-        this.imageUrl = imageUrl;
-        this.role = role;
-        this.provider = provider;
-        this.providerId = providerId;
-        this.gender = gender;
-        this.age = age;
-    }
+	@Column
+	private String providerId;
+
+	@Column
+	private String gender;
+
+	@Column
+	private String age;
+
+	@Builder
+	public User(Long id, String name, String email, String imageUrl, Role role, AuthProvider provider,
+		String providerId, String gender, String age) {
+		this.id = id;
+		this.name = name;
+		this.email = email;
+		this.imageUrl = imageUrl;
+		this.role = role;
+		this.provider = provider;
+		this.providerId = providerId;
+		this.gender = gender;
+		this.age = age;
+	}
 
 }
 

--- a/server/src/test/java/com/ttukttak/chat/CascadeTest.java
+++ b/server/src/test/java/com/ttukttak/chat/CascadeTest.java
@@ -19,7 +19,7 @@ import com.ttukttak.oauth.entity.User;
 import com.ttukttak.oauth.repository.UserRepository;
 
 @SpringBootTest
-public class ChatTest {
+public class CascadeTest {
 
 	@Autowired
 	UserRepository userRepository;
@@ -53,8 +53,8 @@ public class ChatTest {
 		LastCheckedMessage lastCheckedMessage1 = LastCheckedMessage.builder().user(host).build();
 		LastCheckedMessage lastCheckedMessage2 = LastCheckedMessage.builder().user(guest).build();
 
-		chatRoom.addLastchecedMessage(lastCheckedMessage1);
-		chatRoom.addLastchecedMessage(lastCheckedMessage2);
+		chatRoom.addLastCheckedMessage(lastCheckedMessage1);
+		chatRoom.addLastCheckedMessage(lastCheckedMessage2);
 
 		chatRoomRepository.save(chatRoom);
 
@@ -90,7 +90,7 @@ public class ChatTest {
 		// 채팅룸 삭제
 		chatRoomRepository.deleteById(chatRoom.getId());
 
-		LastCheckedMessage findMessage = lastCheckedMessageRepository.findById(messageId).orElseThrow();
+		LastCheckedMessage findMessage = lastCheckedMessageRepository.findById(messageId).orElse(null);
 
 		// LastCheckedMessage도 delete 됐는지 확인
 		Assertions.assertThat(findMessage).isNull();

--- a/server/src/test/java/com/ttukttak/chat/ChatTest.java
+++ b/server/src/test/java/com/ttukttak/chat/ChatTest.java
@@ -1,0 +1,71 @@
+package com.ttukttak.chat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.ttukttak.chat.entity.ChatMessage;
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.chat.entity.LastCheckedMessage;
+import com.ttukttak.chat.repository.ChatMessageRepository;
+import com.ttukttak.chat.repository.ChatRoomRepository;
+import com.ttukttak.chat.repository.LastCheckedMessageRepository;
+import com.ttukttak.oauth.entity.User;
+import com.ttukttak.oauth.repository.UserRepository;
+
+@SpringBootTest
+public class ChatTest {
+
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	ChatMessageRepository chatMessageRepository;
+
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	LastCheckedMessageRepository lastCheckedMessageRepository;
+
+	@Test
+	@DisplayName("room cascade test")
+	void cascadeTest() {
+		User host = User.builder().email("host").build();
+		User guest = User.builder().email("guest").build();
+
+		userRepository.save(host);
+		userRepository.save(guest);
+
+		ChatRoom chatRoom = ChatRoom.builder().host(host).guest(guest).build();
+
+		chatRoomRepository.save(chatRoom);
+
+		ChatMessage chatMessage = ChatMessage.builder().user(host).message("테스트입니다.").build();
+		chatMessageRepository.save(chatMessage);
+
+		LastCheckedMessage lastCheckedMessage = LastCheckedMessage.builder()
+			.message(chatMessage)
+			.room(chatRoom)
+			.user(host)
+			.build();
+		lastCheckedMessageRepository.save(lastCheckedMessage);
+
+		Long lastMessageId = lastCheckedMessage.getId();
+		Long chatMessageId = chatMessage.getId();
+
+		chatRoomRepository.deleteById(chatRoom.getId());
+
+		LastCheckedMessage findLastCheckedMessage = lastCheckedMessageRepository.findById(lastMessageId)
+			.orElse(null);
+
+		ChatMessage findChatMessage = chatMessageRepository.findById(chatMessageId)
+			.orElse(null);
+
+		Assertions.assertThat(chatMessage.getMessage()).isEqualTo("테스트입니다.");
+		Assertions.assertThat(findLastCheckedMessage).isNull();
+		// Assertions.assertThat(findChatMessage).isNull();
+	}
+}

--- a/server/src/test/java/com/ttukttak/chat/ChatTest.java
+++ b/server/src/test/java/com/ttukttak/chat/ChatTest.java
@@ -1,12 +1,15 @@
 package com.ttukttak.chat;
 
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.ttukttak.chat.entity.ChatMessage;
+import com.ttukttak.book.entity.Book;
+import com.ttukttak.book.repository.BookRepository;
 import com.ttukttak.chat.entity.ChatRoom;
 import com.ttukttak.chat.entity.LastCheckedMessage;
 import com.ttukttak.chat.repository.ChatMessageRepository;
@@ -25,47 +28,71 @@ public class ChatTest {
 	ChatMessageRepository chatMessageRepository;
 
 	@Autowired
+	BookRepository bookRepository;
+
+	@Autowired
 	ChatRoomRepository chatRoomRepository;
 
 	@Autowired
 	LastCheckedMessageRepository lastCheckedMessageRepository;
 
 	@Test
-	@DisplayName("room cascade test")
-	void cascadeTest() {
+	@DisplayName("채팅방 Cascade insert 테스트")
+	void cascadeInsertTest() {
 		User host = User.builder().email("host").build();
 		User guest = User.builder().email("guest").build();
 
 		userRepository.save(host);
 		userRepository.save(guest);
 
-		ChatRoom chatRoom = ChatRoom.builder().host(host).guest(guest).build();
+		Book book = Book.builder().owner(host).build();
+		bookRepository.save(book);
+
+		ChatRoom chatRoom = ChatRoom.builder().book(book).build();
+
+		LastCheckedMessage lastCheckedMessage1 = LastCheckedMessage.builder().user(host).build();
+		LastCheckedMessage lastCheckedMessage2 = LastCheckedMessage.builder().user(guest).build();
+
+		chatRoom.addLastchecedMessage(lastCheckedMessage1);
+		chatRoom.addLastchecedMessage(lastCheckedMessage2);
 
 		chatRoomRepository.save(chatRoom);
 
-		ChatMessage chatMessage = ChatMessage.builder().user(host).message("테스트입니다.").build();
-		chatMessageRepository.save(chatMessage);
+		List<LastCheckedMessage> lastCheckedMessages = chatRoom.getLastCheckedMessages();
 
-		LastCheckedMessage lastCheckedMessage = LastCheckedMessage.builder()
-			.message(chatMessage)
-			.room(chatRoom)
-			.user(host)
-			.build();
-		lastCheckedMessageRepository.save(lastCheckedMessage);
-
-		Long lastMessageId = lastCheckedMessage.getId();
-		Long chatMessageId = chatMessage.getId();
-
+		// 채팅룸 삭제
 		chatRoomRepository.deleteById(chatRoom.getId());
 
-		LastCheckedMessage findLastCheckedMessage = lastCheckedMessageRepository.findById(lastMessageId)
-			.orElse(null);
+		// lastCheckedMessage도 insert 됐는지 확인
+		Assertions.assertThat(lastCheckedMessage1.getId()).isNotNull();
+		Assertions.assertThat(lastCheckedMessage2.getId()).isNotNull();
 
-		ChatMessage findChatMessage = chatMessageRepository.findById(chatMessageId)
-			.orElse(null);
+	}
 
-		Assertions.assertThat(chatMessage.getMessage()).isEqualTo("테스트입니다.");
-		Assertions.assertThat(findLastCheckedMessage).isNull();
-		// Assertions.assertThat(findChatMessage).isNull();
+	@Test
+	@DisplayName("채팅방 Cascade delete 테스트")
+	void cascadeDeleteTest() {
+		User user = User.builder().email("user").build();
+
+		userRepository.save(user);
+
+		Book book = Book.builder().owner(user).build();
+		bookRepository.save(book);
+
+		ChatRoom chatRoom = ChatRoom.builder().book(book).build();
+		chatRoomRepository.save(chatRoom);
+
+		LastCheckedMessage lastCheckedMessage = LastCheckedMessage.builder().room(chatRoom).user(user).build();
+		lastCheckedMessageRepository.save(lastCheckedMessage);
+
+		Long messageId = lastCheckedMessage.getId();
+
+		// 채팅룸 삭제
+		chatRoomRepository.deleteById(chatRoom.getId());
+
+		LastCheckedMessage findMessage = lastCheckedMessageRepository.findById(messageId).orElseThrow();
+
+		// LastCheckedMessage도 delete 됐는지 확인
+		Assertions.assertThat(findMessage).isNull();
 	}
 }


### PR DESCRIPTION
## 📕 [BE] 채팅기능 초기 구현


## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 채팅방, 메시지, 참가자, 마지막 읽은 메시지 Entity 추가
- [x] 채팅방, 메시지 DTO
- [x] Redis, WebSocket 설정
- [x] 채팅 레디스 pub/sub 적용
- [x] 채팅 관련 API 구현 및 DTO 추가 구현
- [ ] 채팅 테스트

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 안읽은 메시지 카운트 로직
  1. 메시지를 조회할 때마다 `LastCheckedMessage(마지막으로 확인한 메시지)`를 update
  2. 안읽은 메시지 카운트는 `LastCheckedMessage` 이후의 메시지를 카운트

~~- 도서등록을 고려하지 않고 채팅기능을 구현해서 Entity와 DTO가 추가로 수정될 것 같습니다...~~
