### PR TITLE
[BE]: 채팅 API 구현

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -50,3 +50,6 @@ out/
 *.jar
 *.war
 *.ear
+
+# Querydsl
+/src/main/generated/

--- a/server/src/main/java/com/ttukttak/TtukttakApplication.java
+++ b/server/src/main/java/com/ttukttak/TtukttakApplication.java
@@ -3,9 +3,11 @@ package com.ttukttak;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import com.ttukttak.common.config.AppProperties;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @EnableConfigurationProperties(AppProperties.class)
 public class TtukttakApplication {

--- a/server/src/main/java/com/ttukttak/chat/config/EmbeddedRedisConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/EmbeddedRedisConfig.java
@@ -5,17 +5,14 @@ import javax.annotation.PreDestroy;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 import redis.embedded.RedisServer;
 
-@Profile("default")
 @Configuration
 public class EmbeddedRedisConfig {
 
 	@Value("${spring.redis.port}")
 	private int redisPort;
-
 	private RedisServer redisServer;
 
 	@PostConstruct
@@ -30,4 +27,5 @@ public class EmbeddedRedisConfig {
 			redisServer.stop();
 		}
 	}
+
 }

--- a/server/src/main/java/com/ttukttak/chat/config/RedisConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/RedisConfig.java
@@ -1,8 +1,11 @@
 package com.ttukttak.chat.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
@@ -13,6 +16,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Configuration
 public class RedisConfig {
+	@Value("${spring.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+		redisStandaloneConfiguration.setHostName(redisHost);
+		redisStandaloneConfiguration.setPort(redisPort);
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
+	}
 
 	/**
 	 * redis pub/sub 메시지를 처리하는 listener 설정

--- a/server/src/main/java/com/ttukttak/chat/config/WebSocketConfig.java
+++ b/server/src/main/java/com/ttukttak/chat/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/ws-stomp").setAllowedOrigins("*")
+		registry.addEndpoint("/ws-stomp").setAllowedOriginPatterns("*")
 			.withSockJS();
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
@@ -1,17 +1,18 @@
 package com.ttukttak.chat.controller;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.dto.ChatRoomInfo;
+import com.ttukttak.chat.dto.LastCheckedMessageRequest;
 import com.ttukttak.chat.service.ChatMessageService;
 
 import io.swagger.annotations.Api;
@@ -19,10 +20,10 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
-@Api(value = "/message", description = "채팅메시지 API")
+@Api(value = "/messages", description = "채팅메시지 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/message")
+@RequestMapping("/messages")
 public class ChatMessageController {
 	private final ChatMessageService chatMessageService;
 
@@ -34,7 +35,7 @@ public class ChatMessageController {
 		, paramType = "path")
 	@ApiOperation(value = "채팅방 전체 메시지 조회")
 	@GetMapping("/{roomId}")
-	public ResponseEntity<List<ChatMessageDto>> findAllChats(@PathVariable Long roomId) {
+	public ResponseEntity<ChatRoomInfo> findAllChats(@PathVariable Long roomId) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(chatMessageService.getChatMessages(roomId));
@@ -52,5 +53,21 @@ public class ChatMessageController {
 		return ResponseEntity
 			.status(HttpStatus.OK)
 			.body(chatMessageService.saveChatMessage(chatMessageDto));
+	}
+
+	@ApiImplicitParam(
+		name = "chatMessageDto"
+		, value = "채팅메시지"
+		, required = true
+		, dataType = "ChatMessageDto"
+		, paramType = "body")
+	@ApiOperation(value = "마지막으로 확인한 메시지 갱신")
+	@PutMapping("/lastChecked")
+	public ResponseEntity<Boolean> updateLastChecked(@RequestBody LastCheckedMessageRequest request) {
+		chatMessageService.updateLastCheckedMessage(request);
+
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(true);
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
@@ -56,10 +56,10 @@ public class ChatMessageController {
 	}
 
 	@ApiImplicitParam(
-		name = "chatMessageDto"
-		, value = "채팅메시지"
+		name = "LastCheckedMessageRequest"
+		, value = "마지막으로 확인한 메시지"
 		, required = true
-		, dataType = "ChatMessageDto"
+		, dataType = "LastCheckedMessageRequest"
 		, paramType = "body")
 	@ApiOperation(value = "마지막으로 확인한 메시지 갱신")
 	@PutMapping("/lastChecked")

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatMessageController.java
@@ -2,24 +2,55 @@ package com.ttukttak.chat.controller;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ttukttak.chat.dto.ChatMessageDto;
 import com.ttukttak.chat.service.ChatMessageService;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+@Api(value = "/message", description = "채팅메시지 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/message")
 public class ChatMessageController {
 	private final ChatMessageService chatMessageService;
 
+	@ApiImplicitParam(
+		name = "roomId"
+		, value = "채팅방 ID"
+		, required = true
+		, dataType = "long"
+		, paramType = "path")
+	@ApiOperation(value = "채팅방 전체 메시지 조회")
 	@GetMapping("/{roomId}")
-	public List<ChatMessageDto> findAllChats(@PathVariable Long roomId) {
-		return chatMessageService.getChatMessages(roomId);
+	public ResponseEntity<List<ChatMessageDto>> findAllChats(@PathVariable Long roomId) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(chatMessageService.getChatMessages(roomId));
+	}
+
+	@ApiImplicitParam(
+		name = "chatMessageDto"
+		, value = "채팅메시지"
+		, required = true
+		, dataType = "ChatMessageDto"
+		, paramType = "body")
+	@ApiOperation(value = "메시지 저장(테스트용)")
+	@PostMapping
+	public ResponseEntity<ChatMessageDto> insertChat(@RequestBody ChatMessageDto chatMessageDto) {
+		return ResponseEntity
+			.status(HttpStatus.OK)
+			.body(chatMessageService.saveChatMessage(chatMessageDto));
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
@@ -17,8 +17,12 @@ import com.ttukttak.chat.dto.ChatRoomInfo;
 import com.ttukttak.chat.dto.ChatRoomRequest;
 import com.ttukttak.chat.service.ChatRoomService;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+@Api(value = "/chat", description = "채팅방 API")
 @RequiredArgsConstructor
 @Controller
 @RequestMapping("/chat")
@@ -26,7 +30,13 @@ public class ChatRoomController {
 
 	private final ChatRoomService chatRoomService;
 
-	// 모든 채팅방 목록 반환
+	@ApiImplicitParam(
+		name = "userId"
+		, value = "유저 ID"
+		, required = true
+		, dataType = "long"
+		, paramType = "path")
+	@ApiOperation(value = "모든 채팅방 목록 조회")
 	@GetMapping("/rooms/{userId}")
 	@ResponseBody
 	public ResponseEntity<List<ChatRoomCard>> getRooms(@PathVariable Long userId) {
@@ -37,11 +47,17 @@ public class ChatRoomController {
 			.body(chatRooms);
 	}
 
-	// 채팅방 생성
+	@ApiImplicitParam(
+		name = "ChatRoomRequest"
+		, value = "채팅방 생성 Request"
+		, required = true
+		, dataType = "object"
+		, paramType = "body")
+	@ApiOperation(value = "채팅방 생성")
 	@PostMapping("/room")
 	@ResponseBody
-	public ResponseEntity<ChatRoomInfo> createRoom(@RequestBody ChatRoomRequest request) {
-		ChatRoomInfo chatRoomInfo = chatRoomService.createChatRoom(request);
+	public ResponseEntity<ChatRoomInfo> createRoom(@RequestBody ChatRoomRequest chatRoomRequest) {
+		ChatRoomInfo chatRoomInfo = chatRoomService.createChatRoom(chatRoomRequest);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
+++ b/server/src/main/java/com/ttukttak/chat/controller/ChatRoomController.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.ttukttak.chat.dto.ChatRoomCard;
@@ -40,7 +40,7 @@ public class ChatRoomController {
 	// 채팅방 생성
 	@PostMapping("/room")
 	@ResponseBody
-	public ResponseEntity<ChatRoomInfo> createRoom(@RequestParam ChatRoomRequest request) {
+	public ResponseEntity<ChatRoomInfo> createRoom(@RequestBody ChatRoomRequest request) {
 		ChatRoomInfo chatRoomInfo = chatRoomService.createChatRoom(request);
 
 		return ResponseEntity

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
@@ -1,5 +1,6 @@
 package com.ttukttak.chat.dto;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 import com.ttukttak.chat.entity.ChatMessage;
@@ -17,7 +18,9 @@ import lombok.ToString;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-public class ChatMessageDto {
+public class ChatMessageDto implements Serializable {
+	private static final long serialVersionUID = 1L;
+	
 	private Long id;
 	private Long userId;
 	private Long roomId;
@@ -35,7 +38,6 @@ public class ChatMessageDto {
 			.user(user)
 			.message(message)
 			.messageType(messageType)
-			.sendedAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
@@ -3,10 +3,6 @@ package com.ttukttak.chat.dto;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 
-import com.ttukttak.chat.entity.ChatMessage;
-import com.ttukttak.chat.entity.ChatRoom;
-import com.ttukttak.oauth.entity.User;
-
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -40,15 +36,4 @@ public class ChatMessageDto implements Serializable {
 	@ApiModelProperty
 	private LocalDateTime sendedAt;
 
-	public ChatMessage toEntity() {
-		ChatRoom chatRoom = ChatRoom.builder().id(roomId).build();
-		User user = User.builder().id(userId).build();
-
-		return ChatMessage.builder()
-			.chatRoom(chatRoom)
-			.user(user)
-			.message(message)
-			.messageType(messageType)
-			.build();
-	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatMessageDto.java
@@ -7,6 +7,7 @@ import com.ttukttak.chat.entity.ChatMessage;
 import com.ttukttak.chat.entity.ChatRoom;
 import com.ttukttak.oauth.entity.User;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,13 +21,23 @@ import lombok.ToString;
 @ToString
 public class ChatMessageDto implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
+	@ApiModelProperty
 	private Long id;
+
+	@ApiModelProperty(example = "보낸사람 ID")
 	private Long userId;
+
+	@ApiModelProperty(example = "채팅방 ID")
 	private Long roomId;
+
+	@ApiModelProperty(example = "메시지 내용")
 	private String message;
+
+	@ApiModelProperty(example = "TEXT or FILE")
 	private MessageType messageType;
 
+	@ApiModelProperty
 	private LocalDateTime sendedAt;
 
 	public ChatMessage toEntity() {

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
@@ -3,6 +3,7 @@ package com.ttukttak.chat.dto;
 import java.io.Serializable;
 
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,18 +13,19 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class ChatRoomCard implements Serializable {
 	private static final long serialVersionUID = 1L;
 	private Long roomId;
 	private ChatUser other;
 	private LastMessage lastMessage;
-	private int count = 0;
+	private int unread = 0;
 
 	@Builder
-	public ChatRoomCard(Long roomId, ChatUser other, LastMessage lastMessage, int count) {
+	public ChatRoomCard(Long roomId, ChatUser other, LastMessage lastMessage, int unread) {
 		this.roomId = roomId;
 		this.other = other;
 		this.lastMessage = lastMessage;
-		this.count = count;
+		this.unread = unread;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomCard.java
@@ -1,6 +1,8 @@
 package com.ttukttak.chat.dto;
 
-import lombok.AllArgsConstructor;
+import java.io.Serializable;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,12 +11,19 @@ import lombok.ToString;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @ToString
-public class ChatRoomCard {
+public class ChatRoomCard implements Serializable {
+	private static final long serialVersionUID = 1L;
 	private Long roomId;
-	private Long bookId;
 	private ChatUser other;
 	private LastMessage lastMessage;
+	private int count = 0;
 
+	@Builder
+	public ChatRoomCard(Long roomId, ChatUser other, LastMessage lastMessage, int count) {
+		this.roomId = roomId;
+		this.other = other;
+		this.lastMessage = lastMessage;
+		this.count = count;
+	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
@@ -1,8 +1,11 @@
 package com.ttukttak.chat.dto;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,10 +14,21 @@ import lombok.ToString;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @ToString
+@EqualsAndHashCode
 public class ChatRoomInfo implements Serializable {
 	private static final long serialVersionUID = 1L;
-	
+
 	private Long roomId;
+
+	private List<ChatUser> members;
+
+	private List<ChatMessageDto> messages = new ArrayList<>();
+
+	@Builder
+	public ChatRoomInfo(Long roomId, List<ChatUser> members, List<ChatMessageDto> messages) {
+		this.roomId = roomId;
+		this.members = members;
+		this.messages = messages;
+	}
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomInfo.java
@@ -1,6 +1,6 @@
 package com.ttukttak.chat.dto;
 
-import java.util.List;
+import java.io.Serializable;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,8 +13,8 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ChatRoomInfo {
-
+public class ChatRoomInfo implements Serializable {
+	private static final long serialVersionUID = 1L;
+	
 	private Long roomId;
-	private List<ChatUser> users;
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatRoomRequest.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatRoomRequest.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class ChatRoomRequest {
 	private Long bookId;
 	private Long userId;

--- a/server/src/main/java/com/ttukttak/chat/dto/ChatUser.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/ChatUser.java
@@ -1,5 +1,7 @@
 package com.ttukttak.chat.dto;
 
+import java.io.Serializable;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +13,9 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
-public class ChatUser {
+public class ChatUser implements Serializable {
+	private static final long serialVersionUID = 1L;
 	private Long id;
 	private String name;
+	private String imageUrl;
 }

--- a/server/src/main/java/com/ttukttak/chat/dto/LastCheckedMessageRequest.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/LastCheckedMessageRequest.java
@@ -1,0 +1,28 @@
+package com.ttukttak.chat.dto;
+
+import java.io.Serializable;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class LastCheckedMessageRequest implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@ApiModelProperty(example = "메시지 ID")
+	private Long messageId;
+
+	@ApiModelProperty(example = "채팅방 ID")
+	private Long roomId;
+
+	@ApiModelProperty(example = "확인한 유저 ID")
+	private Long userId;
+}

--- a/server/src/main/java/com/ttukttak/chat/dto/LastMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/dto/LastMessage.java
@@ -1,8 +1,22 @@
 package com.ttukttak.chat.dto;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
-public class LastMessage {
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class LastMessage implements Serializable {
+	private static final long serialVersionUID = 1L;
+
 	private String message;
 	private MessageType messageType;
 	private LocalDateTime sendedAt;

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
@@ -15,6 +16,8 @@ import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.ttukttak.chat.dto.MessageType;
 import com.ttukttak.oauth.entity.User;
@@ -22,10 +25,13 @@ import com.ttukttak.oauth.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor
 @Getter
 @Entity
+@ToString
+@EntityListeners(AuditingEntityListener.class)
 public class ChatMessage implements Serializable {
 	private static final long serialVersionUID = 1L;
 
@@ -48,16 +54,15 @@ public class ChatMessage implements Serializable {
 	@ColumnDefault("'TEXT'")
 	private MessageType messageType;
 
+	@CreatedDate
 	private LocalDateTime sendedAt;
 
 	@Builder
-	public ChatMessage(Long id, ChatRoom chatRoom, User user, String message, MessageType messageType,
-		LocalDateTime sendedAt) {
+	public ChatMessage(Long id, ChatRoom chatRoom, User user, String message, MessageType messageType) {
 		this.id = id;
 		this.chatRoom = chatRoom;
 		this.user = user;
 		this.message = message;
 		this.messageType = messageType;
-		this.sendedAt = sendedAt;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatMessage.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.ttukttak.chat.dto.ChatMessageDto;
 import com.ttukttak.chat.dto.MessageType;
 import com.ttukttak.oauth.entity.User;
 
@@ -64,5 +65,17 @@ public class ChatMessage implements Serializable {
 		this.user = user;
 		this.message = message;
 		this.messageType = messageType;
+	}
+
+	public static ChatMessage of(ChatMessageDto chatMessageDto) {
+		ChatRoom chatRoom = ChatRoom.builder().id(chatMessageDto.getRoomId()).build();
+		User user = User.builder().id(chatMessageDto.getUserId()).build();
+
+		return ChatMessage.builder()
+			.chatRoom(chatRoom)
+			.user(user)
+			.message(chatMessageDto.getMessage())
+			.messageType(chatMessageDto.getMessageType())
+			.build();
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/ChatRoom.java
@@ -14,6 +14,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 
+import net.minidev.json.annotate.JsonIgnore;
+
 import com.ttukttak.book.entity.Book;
 import com.ttukttak.common.BaseTimeEntity;
 
@@ -35,9 +37,11 @@ public class ChatRoom extends BaseTimeEntity implements Serializable {
 	@JoinColumn(name = "book_id")
 	private Book book;
 
+	@JsonIgnore
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom")
 	private List<ChatMessage> messages = new ArrayList<>();
 
+	@JsonIgnore
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<LastCheckedMessage> lastCheckedMessages = new ArrayList<>();
 

--- a/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
+++ b/server/src/main/java/com/ttukttak/chat/entity/LastCheckedMessage.java
@@ -15,9 +15,11 @@ import com.ttukttak.oauth.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor
 @Getter
+@ToString
 @Entity
 public class LastCheckedMessage implements Serializable {
 	private static final long serialVersionUID = 1L;
@@ -46,6 +48,10 @@ public class LastCheckedMessage implements Serializable {
 	public LastCheckedMessage(User user, ChatRoom room, ChatMessage chatMessage) {
 		this.user = user;
 		this.room = room;
+		this.chatMessage = chatMessage;
+	}
+
+	public void setChatMessage(ChatMessage chatMessage) {
 		this.chatMessage = chatMessage;
 	}
 }

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ttukttak.chat.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-	List<ChatMessage> findAllByChatRoomIdOOrderBySendedAtAsc(Long roomId);
+	List<ChatMessage> findAllByChatRoomIdOrderBySendedAtAsc(Long roomId);
 
 	int countByChatRoomIdAndSendedAtAfterAndUserIdNot(Long roomId, LocalDateTime sendedAt, Long userId);
 

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package com.ttukttak.chat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ttukttak.chat.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-	List<ChatMessage> findAllByRoomId(Long roomId);
+	List<ChatMessage> findAllByChatRoomId(Long roomId);
+
+	int countByChatRoomIdAndSendedAtAfterAndUserIdNot(Long roomId, LocalDateTime sendedAt, Long userId);
+
+	ChatMessage findFirstByChatRoomIdOrderBySendedAtDesc(Long roomId);
 }

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatMessageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ttukttak.chat.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-	List<ChatMessage> findAllByChatRoomId(Long roomId);
+	List<ChatMessage> findAllByChatRoomIdOOrderBySendedAtAsc(Long roomId);
 
 	int countByChatRoomIdAndSendedAtAfterAndUserIdNot(Long roomId, LocalDateTime sendedAt, Long userId);
 

--- a/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepositoryCustom.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/ChatRoomRepositoryCustom.java
@@ -4,8 +4,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.chat.entity.LastCheckedMessage;
 import com.ttukttak.chat.entity.QChatRoom;
 import com.ttukttak.chat.entity.QLastCheckedMessage;
 
@@ -17,12 +18,19 @@ public class ChatRoomRepositoryCustom {
 
 	private final JPAQueryFactory query;
 
-	public List<ChatRoom> findAllChatRoomByUserId(Long userId) {
-		QChatRoom cr = new QChatRoom("cr");
+	public List<LastCheckedMessage> findAllChatRoomByUserId(Long userId) {
+		QChatRoom chatRoom = new QChatRoom("cr");
 		QLastCheckedMessage lcm = new QLastCheckedMessage("lcm");
+		QLastCheckedMessage lcm2 = new QLastCheckedMessage("lcm2");
 
-		return query.selectFrom(cr)
-			.where(lcm.user.id.eq(userId), lcm.room.id.eq(cr.id))
+		return query.selectFrom(lcm)
+			.where(lcm.room.in(
+				JPAExpressions
+					.selectFrom(chatRoom)
+					.join(lcm2)
+					.on(chatRoom.eq(lcm2.room))
+					.where(lcm2.user.id.eq(userId))
+			), lcm.user.id.ne(userId))
 			.fetch();
 	}
 

--- a/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
@@ -1,9 +1,13 @@
 package com.ttukttak.chat.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ttukttak.chat.entity.LastCheckedMessage;
 
 public interface LastCheckedMessageRepository extends JpaRepository<LastCheckedMessage, Long> {
 	LastCheckedMessage findByRoomIdAndUserId(Long roomId, Long userId);
+
+	List<LastCheckedMessage> findAllByRoomId(Long roomId);
 }

--- a/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
+++ b/server/src/main/java/com/ttukttak/chat/repository/LastCheckedMessageRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ttukttak.chat.entity.LastCheckedMessage;
 
 public interface LastCheckedMessageRepository extends JpaRepository<LastCheckedMessage, Long> {
+	LastCheckedMessage findByRoomIdAndUserId(Long roomId, Long userId);
 }

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.ttukttak.chat.dto.ChatMessageDto;
 
 public interface ChatMessageService {
-	void saveChatMessage(ChatMessageDto chatMessageDto);
+	ChatMessageDto saveChatMessage(ChatMessageDto chatMessageDto);
 
 	List<ChatMessageDto> getChatMessages(Long roomId);
 }

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageService.java
@@ -1,11 +1,13 @@
 package com.ttukttak.chat.service;
 
-import java.util.List;
-
 import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.dto.ChatRoomInfo;
+import com.ttukttak.chat.dto.LastCheckedMessageRequest;
 
 public interface ChatMessageService {
 	ChatMessageDto saveChatMessage(ChatMessageDto chatMessageDto);
 
-	List<ChatMessageDto> getChatMessages(Long roomId);
+	ChatRoomInfo getChatMessages(Long roomId);
+
+	void updateLastCheckedMessage(LastCheckedMessageRequest request);
 }

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
@@ -25,7 +25,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 	@Override
 	public List<ChatMessageDto> getChatMessages(Long roomId) {
 
-		return chatMessageRepository.findAllByRoomId(roomId)
+		return chatMessageRepository.findAllByChatRoomId(roomId)
 			.stream()
 			.map(chatMessage -> modelMapper.map(chatMessage, ChatMessageDto.class))
 			.collect(Collectors.toList());

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
@@ -18,8 +18,9 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 	private final ChatMessageRepository chatMessageRepository;
 
 	@Override
-	public void saveChatMessage(ChatMessageDto chatMessageDto) {
+	public ChatMessageDto saveChatMessage(ChatMessageDto chatMessageDto) {
 		chatMessageRepository.save(chatMessageDto.toEntity());
+		return chatMessageDto;
 	}
 
 	@Override

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
@@ -33,7 +33,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 	@Override
 	public ChatRoomInfo getChatMessages(Long roomId) {
 
-		List<ChatMessageDto> messages = chatMessageRepository.findAllByChatRoomId(roomId)
+		List<ChatMessageDto> messages = chatMessageRepository.findAllByChatRoomIdOOrderBySendedAtAsc(roomId)
 			.stream()
 			.map(chatMessage -> modelMapper.map(chatMessage, ChatMessageDto.class))
 			.collect(Collectors.toList());

--- a/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatMessageServiceImpl.java
@@ -33,7 +33,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 	@Override
 	public ChatRoomInfo getChatMessages(Long roomId) {
 
-		List<ChatMessageDto> messages = chatMessageRepository.findAllByChatRoomIdOOrderBySendedAtAsc(roomId)
+		List<ChatMessageDto> messages = chatMessageRepository.findAllByChatRoomIdOrderBySendedAtAsc(roomId)
 			.stream()
 			.map(chatMessage -> modelMapper.map(chatMessage, ChatMessageDto.class))
 			.collect(Collectors.toList());

--- a/server/src/main/java/com/ttukttak/chat/service/ChatRoomService.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatRoomService.java
@@ -11,8 +11,6 @@ import com.ttukttak.chat.dto.ChatRoomRequest;
 public interface ChatRoomService {
 	List<ChatRoomCard> getRoomList(Long userId);
 
-	ChatRoomInfo findRoomById(Long id);
-
 	/**
 	 * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
 	 */

--- a/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
@@ -56,7 +56,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 	// Redis
 	private static final String CHAT_ROOMS = "CHAT_ROOM";
 	private final RedisTemplate<String, Object> redisTemplate;
-	private HashOperations<String, Long, ChatRoomInfo> opsHashChatRoom;
+	private HashOperations<String, Long, ChatRoom> opsHashChatRoom;
 
 	// 채팅방의 대화 메시지를 발행하기 위한 redis topic 정보. 서버별로 채팅방에 매치되는 topic정보를 Map에 넣어 roomId로 찾을수 있도록 한다.
 	private Map<Long, ChannelTopic> topics;
@@ -99,10 +99,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 		}).collect(Collectors.toList());
 	}
 
-	public ChatRoomInfo findRoomById(Long id) {
-		return opsHashChatRoom.get(CHAT_ROOMS, id);
-	}
-
 	/**
 	 * 채팅방 생성 : 서버간 채팅방 공유를 위해 redis hash에 저장한다.
 	 */
@@ -130,11 +126,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
 		log.info(chatRoom.getId() + " : 생성");
 
-		ChatRoomInfo chatRoomInfo = modelMapper.map(chatRoom, ChatRoomInfo.class);
+		opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getId(), chatRoom);
 
-		opsHashChatRoom.put(CHAT_ROOMS, chatRoom.getId(), chatRoomInfo);
-
-		return chatRoomInfo;
+		return ChatRoomInfo.builder().roomId(chatRoom.getId()).build();
 	}
 
 	/**

--- a/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/chat/service/ChatRoomServiceImpl.java
@@ -69,8 +69,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
 	@Override
 	public List<ChatRoomCard> getRoomList(Long userId) {
-		return chatRoomRepositoryCustom.findAllChatRoomByUserId(userId).stream().map(participantInfo -> {
-			ChatRoom room = participantInfo.getRoom();
+		return chatRoomRepositoryCustom.findAllChatRoomByUserId(userId).stream().map(findRoom -> {
+			ChatRoom room = findRoom.getRoom();
 			ChatMessage lastChatMessage = chatMessageRepository.findFirstByChatRoomIdOrderBySendedAtDesc(room.getId());
 
 			LastCheckedMessage lastCheckedMessage = lastCheckedMessageRepository.findByRoomIdAndUserId(room.getId(),
@@ -82,19 +82,19 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 				lastMessage = modelMapper.map(lastChatMessage, LastMessage.class);
 			}
 
-			LocalDateTime lastCheckedTime = participantInfo.getRoom().getCreatedDate();
+			LocalDateTime lastCheckedTime = findRoom.getRoom().getCreatedDate();
 
 			if (lastCheckedMessage.getChatMessage() != null) {
 				lastCheckedTime = lastCheckedMessage.getChatMessage().getSendedAt();
 			}
 
 			int unReadCount = chatMessageRepository.countByChatRoomIdAndSendedAtAfterAndUserIdNot(
-				participantInfo.getRoom().getId(), lastCheckedTime, userId);
+				findRoom.getRoom().getId(), lastCheckedTime, userId);
 
-			return ChatRoomCard.builder().roomId(participantInfo.getRoom().getId())
-				.other(modelMapper.map(participantInfo.getUser(), ChatUser.class))
+			return ChatRoomCard.builder().roomId(findRoom.getRoom().getId())
+				.other(modelMapper.map(findRoom.getUser(), ChatUser.class))
 				.lastMessage(lastMessage)
-				.count(unReadCount)
+				.unread(unReadCount)
 				.build();
 		}).collect(Collectors.toList());
 	}

--- a/server/src/main/java/com/ttukttak/chat/service/RedisSubscriber.java
+++ b/server/src/main/java/com/ttukttak/chat/service/RedisSubscriber.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.entity.ChatMessage;
 import com.ttukttak.chat.repository.ChatMessageRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class RedisSubscriber implements MessageListener {
 			String publishMessage = (String)redisTemplate.getStringSerializer().deserialize(message.getBody());
 			ChatMessageDto roomMessage = objectMapper.readValue(publishMessage, ChatMessageDto.class);
 
-			chatMessageRepository.save(roomMessage.toEntity());
+			chatMessageRepository.save(ChatMessage.of(roomMessage));
 
 			log.info("redis 수신 : {}", roomMessage);
 			// Websocket 구독자에게 채팅 메시지 Send

--- a/server/src/main/java/com/ttukttak/common/config/SwaggerConfig.java
+++ b/server/src/main/java/com/ttukttak/common/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com.ttukttak.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+	private static final String API_NAME = "개인책방 API";
+	private static final String API_VERSION = "0.0.1";
+	private static final String API_DESCRIPTION = "개인책방 API 명세서";
+
+	@Bean
+	public Docket api() {
+		return new Docket(DocumentationType.SWAGGER_2)
+			.apiInfo(apiInfo())
+			.select()
+			.apis(RequestHandlerSelectors.basePackage("com.ttukttak"))
+			.paths(PathSelectors.any())
+			.build();
+	}
+
+	public ApiInfo apiInfo() {
+		return new ApiInfoBuilder()
+			.title(API_NAME)
+			.version(API_VERSION)
+			.description(API_DESCRIPTION)
+			.build();
+	}
+}

--- a/server/src/test/java/com/ttukttak/chat/ChatMessageTest.java
+++ b/server/src/test/java/com/ttukttak/chat/ChatMessageTest.java
@@ -1,0 +1,29 @@
+package com.ttukttak.chat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.dto.MessageType;
+import com.ttukttak.chat.entity.ChatMessage;
+import com.ttukttak.chat.repository.ChatMessageRepository;
+
+@SpringBootTest
+public class ChatMessageTest {
+	@Autowired
+	ChatMessageRepository chatMessageRepository;
+
+	@Test
+	@DisplayName("ChatMessage.of 테스트")
+	void ofTest() {
+		ChatMessageDto chatMessageDto = new ChatMessageDto();
+		chatMessageDto.setMessage("test");
+		chatMessageDto.setMessageType(MessageType.TEXT);
+		chatMessageDto.setRoomId(1L);
+		chatMessageDto.setUserId(1L);
+
+		chatMessageRepository.save(ChatMessage.of(chatMessageDto));
+	}
+}

--- a/server/src/test/java/com/ttukttak/chat/MappingTest.java
+++ b/server/src/test/java/com/ttukttak/chat/MappingTest.java
@@ -1,0 +1,137 @@
+package com.ttukttak.chat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.ttukttak.book.entity.Book;
+import com.ttukttak.book.repository.BookRepository;
+import com.ttukttak.chat.dto.ChatMessageDto;
+import com.ttukttak.chat.dto.MessageType;
+import com.ttukttak.chat.entity.ChatMessage;
+import com.ttukttak.chat.entity.ChatRoom;
+import com.ttukttak.chat.entity.LastCheckedMessage;
+import com.ttukttak.chat.repository.ChatMessageRepository;
+import com.ttukttak.chat.repository.ChatRoomRepository;
+import com.ttukttak.chat.repository.ChatRoomRepositoryCustom;
+import com.ttukttak.chat.repository.LastCheckedMessageRepository;
+import com.ttukttak.oauth.entity.User;
+import com.ttukttak.oauth.repository.UserRepository;
+
+@SpringBootTest
+public class MappingTest {
+	@Autowired
+	UserRepository userRepository;
+
+	@Autowired
+	ChatMessageRepository chatMessageRepository;
+
+	@Autowired
+	BookRepository bookRepository;
+
+	@Autowired
+	ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	LastCheckedMessageRepository lastCheckedMessageRepository;
+
+	@Autowired
+	ChatRoomRepositoryCustom chatRoomRepositoryCustom;
+
+	@Autowired
+	ModelMapper modelMapper;
+
+	@Test
+	@DisplayName("ChatMessageDto 맵핑")
+	void chatMessageDto() {
+		User user = User.builder().email("user@naver.com").age("20").name("테스터").gender("M").build();
+
+		userRepository.save(user);
+
+		Book book = Book.builder().owner(user).build();
+		bookRepository.save(book);
+
+		ChatRoom chatRoom = ChatRoom.builder().book(book).build();
+
+		LastCheckedMessage lastCheckedMessage = LastCheckedMessage.builder().user(user).build();
+
+		chatRoom.addLastCheckedMessage(lastCheckedMessage);
+
+		chatRoomRepository.save(chatRoom);
+
+		ChatMessage chatMessage = ChatMessage.builder()
+			.message("test message")
+			.chatRoom(chatRoom)
+			.user(user)
+			.messageType(MessageType.TEXT)
+			.build();
+
+		chatMessageRepository.save(chatMessage);
+
+		ChatMessageDto chatMessageDto = modelMapper.map(chatMessage, ChatMessageDto.class);
+
+		System.out.println(chatMessageDto);
+
+		Assertions.assertThat(chatMessageDto.getId()).isEqualTo(chatMessage.getId());
+		Assertions.assertThat(chatMessageDto.getUserId()).isEqualTo(chatMessage.getUser().getId());
+		Assertions.assertThat(chatMessageDto.getRoomId()).isEqualTo(chatMessage.getChatRoom().getId());
+		Assertions.assertThat(chatMessageDto.getMessage()).isEqualTo(chatMessage.getMessage());
+		Assertions.assertThat(chatMessageDto.getMessageType()).isEqualTo(chatMessage.getMessageType());
+		Assertions.assertThat(chatMessageDto.getSendedAt()).isEqualTo(chatMessage.getSendedAt());
+
+	}
+
+	@Test
+	@DisplayName("ChatRoomCard 맵핑")
+	void chatRoomCard() {
+		User user = User.builder().email("user@naver.com").age("20").name("테스터").gender("M").build();
+
+		userRepository.save(user);
+
+		Book book = Book.builder().owner(user).build();
+		bookRepository.save(book);
+
+		ChatRoom chatRoom = ChatRoom.builder().book(book).build();
+
+		LastCheckedMessage lastCheckedMessage = LastCheckedMessage.builder().user(user).build();
+
+		chatRoom.addLastCheckedMessage(lastCheckedMessage);
+
+		chatRoomRepository.save(chatRoom);
+
+		ChatMessage chatMessage = ChatMessage.builder()
+			.message("test message")
+			.chatRoom(chatRoom)
+			.user(user)
+			.messageType(MessageType.TEXT)
+			.build();
+
+		chatMessageRepository.save(chatMessage);
+
+		lastCheckedMessage.setChatMessage(chatMessage);
+
+		lastCheckedMessageRepository.save(lastCheckedMessage);
+
+		LastCheckedMessage findMessage = chatRoomRepositoryCustom.findAllChatRoomByUserId(user.getId()).get(0);
+
+		// ChatRoomCard chatRoomCard = modelMapper.typeMap(ChatRoom.class, ChatRoomCard.class)
+		// 	.addMappings(mapper -> {
+		// 		mapper.map(ChatRoom::getLastCheckedMessages)
+		// 	})
+
+		// System.out.println(chatRoomCard);
+
+		Assertions.assertThat(findMessage.getId()).isEqualTo(lastCheckedMessage.getId());
+		// Assertions.assertThat(chatRoomCard.getRoomId()).isEqualTo(chatRoom.getId());
+		// ChatRoomCard card = cardList.get(0);
+
+		// System.out.println(cardList.get(0).toString());
+
+		// Assertions.assertThat(cardList.size()).isEqualTo(1);
+
+	}
+
+}


### PR DESCRIPTION
## 📕 [BE]: 채팅 API 구현



## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] swagger 설정
- [x] 마지막 읽은 메시지 갱신 API
- [x] 메시지 조회 API
- [x] 채팅방 리스트 조회 API
- [ ] 메시지 조회 시 마지막 읽은 메시지 자동갱신

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

마지막으로 확인한 메시지 갱신하는 시나리오가 2가지 있는데
- 채팅방 들어갔을 때
  - 상대 메시지중에 가장 마지막 메시지 id로 갱신

- 채팅방 접속한 상태에서 메시지 주고 받을 때
  - 상대 메시지를 받으면 해당 메시지 id로 실시간으로 갱신


1번은 서버에서 채팅방 메시지 조회할 때 스프링 시큐리티로 User.id 값을 받아서 갱신
2번은 채팅 화면에서 상대방의 메시지를 받을 때 실시간으로 프론트에서 갱신 API사용
