### PR TITLE
[BE] User 연관관계 추가 및 회원가입 반환값 수정

### DIFF
--- a/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
+++ b/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
 	public ResponseEntity<UserDto> getCurrentUser(@CurrentUser
 	UserPrincipal userPrincipal) {
 
-		UserDto userDto = new UserDto(userPrincipal.getUser());
+		UserDto userDto = userService.getById(userPrincipal.getId());
 
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
+++ b/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
@@ -43,11 +43,12 @@ public class UserController {
 	@ApiImplicitParam(name = "nickname", value = "닉네임", required = true, dataType = "String", paramType = "Param")
 	@ApiOperation(value = "닉네임 중복 체크")
 	@GetMapping("/chknickname")
-	public ResponseEntity<Boolean> chkName(@RequestParam
+	public ResponseEntity<Boolean> chkName(@CurrentUser
+	UserPrincipal userPrincipal, @RequestParam
 	String nickname) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
-			.body(userService.existsByName(nickname));
+			.body(userService.existsByName(nickname, userPrincipal.getId()));
 	}
 
 	@ApiImplicitParams({

--- a/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
+++ b/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
@@ -57,15 +57,15 @@ public class UserController {
 	})
 	@ApiOperation(value = "회원가입")
 	@PostMapping("/signup")
-	public ResponseEntity<Boolean> setSignUp(@CurrentUser
+	public ResponseEntity<UserDto> setSignUp(@CurrentUser
 	UserPrincipal userPrincipal, SignUpRequest signUpRequest, @RequestBody
 	MultipartFile imageFile) {
 
-		Boolean queryChk = userService.setSignUp(userPrincipal.getUser(), signUpRequest, imageFile);
+		UserDto userDto = userService.setSignUp(userPrincipal.getUser(), signUpRequest, imageFile);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)
-			.body(queryChk);
+			.body(userDto);
 
 	}
 }

--- a/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
+++ b/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,9 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.ttukttak.oauth.dto.SignUpRequest;
 import com.ttukttak.oauth.dto.UserDto;
-import com.ttukttak.oauth.entity.CurrentUser;
-import com.ttukttak.oauth.entity.UserPrincipal;
 import com.ttukttak.oauth.service.UserService;
+import com.ttukttak.oauth.token.TokenProvider;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -29,13 +29,16 @@ import lombok.RequiredArgsConstructor;
 public class UserController {
 
 	private final UserService userService;
+	private final TokenProvider tokenProvider;
 
 	@ApiOperation(value = "로그인한 유저정보 조회")
 	@GetMapping("/me")
-	public ResponseEntity<UserDto> getCurrentUser(@CurrentUser
-	UserPrincipal userPrincipal) {
+	public ResponseEntity<UserDto> getCurrentUser(@RequestHeader(name = "Authorization")
+	String token) {
 
-		UserDto userDto = userService.getById(userPrincipal.getId());
+		Long userId = tokenProvider.getUserIdFromToken(tokenProvider.getJwtFromHeader(token));
+
+		UserDto userDto = userService.getById(userId);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)
@@ -45,12 +48,14 @@ public class UserController {
 	@ApiImplicitParam(name = "nickname", value = "닉네임", required = true, dataType = "String", paramType = "Param")
 	@ApiOperation(value = "닉네임 중복 체크")
 	@GetMapping("/chknickname")
-	public ResponseEntity<Boolean> chkName(@CurrentUser
-	UserPrincipal userPrincipal, @RequestParam
+	public ResponseEntity<Boolean> chkName(@RequestHeader(name = "Authorization")
+	String token, @RequestParam
 	String nickname) {
+		Long userId = tokenProvider.getUserIdFromToken(tokenProvider.getJwtFromHeader(token));
+
 		return ResponseEntity
 			.status(HttpStatus.OK)
-			.body(userService.existsByName(nickname, userPrincipal.getId()));
+			.body(userService.existsByName(nickname, userId));
 	}
 
 	@ApiImplicitParams({
@@ -59,11 +64,12 @@ public class UserController {
 	})
 	@ApiOperation(value = "회원가입")
 	@PostMapping("/signup")
-	public ResponseEntity<UserDto> setSignUp(@CurrentUser
-	UserPrincipal userPrincipal, SignUpRequest signUpRequest, @RequestBody
+	public ResponseEntity<UserDto> setSignUp(@RequestHeader(name = "Authorization")
+	String token, SignUpRequest signUpRequest, @RequestBody
 	MultipartFile imageFile) {
+		Long userId = tokenProvider.getUserIdFromToken(tokenProvider.getJwtFromHeader(token));
 
-		UserDto userDto = userService.setSignUp(userPrincipal.getUser(), signUpRequest, imageFile);
+		UserDto userDto = userService.setSignUp(userId, signUpRequest, imageFile);
 
 		return ResponseEntity
 			.status(HttpStatus.OK)

--- a/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
+++ b/server/src/main/java/com/ttukttak/oauth/controller/UserController.java
@@ -16,14 +16,16 @@ import com.ttukttak.oauth.entity.CurrentUser;
 import com.ttukttak.oauth.entity.UserPrincipal;
 import com.ttukttak.oauth.service.UserService;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 
+@Api(value = "/api/user", description = "유저 API")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/api/user")
 public class UserController {
 
 	private final UserService userService;

--- a/server/src/main/java/com/ttukttak/oauth/dto/SignUpRequest.java
+++ b/server/src/main/java/com/ttukttak/oauth/dto/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.ttukttak.oauth.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -8,7 +9,11 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class SignUpRequest {
+
+	@ApiModelProperty(example = "닉네임")
 	private String nickname;
+
+	@ApiModelProperty(example = "지역 ID")
 	private Long townId;
 	/*
 	 * request 받을때 해당값이 없을 경우 bind 에러 발생으로 제외

--- a/server/src/main/java/com/ttukttak/oauth/dto/UserDto.java
+++ b/server/src/main/java/com/ttukttak/oauth/dto/UserDto.java
@@ -1,5 +1,9 @@
 package com.ttukttak.oauth.dto;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ttukttak.address.dto.HomeTownDto;
 import com.ttukttak.oauth.entity.Role;
 import com.ttukttak.oauth.entity.User;
 
@@ -16,6 +20,7 @@ public class UserDto {
 	private String email;
 	private String imageUrl;
 	private Role role;
+	private List<HomeTownDto> homeTown;
 
 	public UserDto(User user) {
 		this.id = user.getId();
@@ -23,6 +28,10 @@ public class UserDto {
 		this.email = user.getEmail();
 		this.imageUrl = user.getImageUrl();
 		this.role = user.getRole();
+		this.homeTown = user.getHomeTown()
+			.stream()
+			.map(c -> new HomeTownDto(c))
+			.collect(Collectors.toList());
 	}
 
 }

--- a/server/src/main/java/com/ttukttak/oauth/entity/User.java
+++ b/server/src/main/java/com/ttukttak/oauth/entity/User.java
@@ -1,15 +1,21 @@
 package com.ttukttak.oauth.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.sun.istack.NotNull;
+import com.ttukttak.address.entity.HomeTown;
 import com.ttukttak.common.BaseTimeEntity;
 import com.ttukttak.oauth.dto.UserDto;
 
@@ -52,6 +58,9 @@ public class User extends BaseTimeEntity {
 
 	@Column
 	private String age;
+
+	@OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
+	private List<HomeTown> homeTown = new ArrayList<>();
 
 	@Builder
 	public User(Long id, String nickname, String email, String imageUrl, Role role, AuthProvider provider,

--- a/server/src/main/java/com/ttukttak/oauth/repository/UserRepository.java
+++ b/server/src/main/java/com/ttukttak/oauth/repository/UserRepository.java
@@ -12,6 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
 
-	Boolean existsByNickname(String nickname);
+	Boolean existsByNicknameAndIdNot(String nickname, Long id);
 
 }

--- a/server/src/main/java/com/ttukttak/oauth/service/UserService.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserService.java
@@ -4,7 +4,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.ttukttak.oauth.dto.SignUpRequest;
 import com.ttukttak.oauth.dto.UserDto;
-import com.ttukttak.oauth.entity.User;
 
 public interface UserService {
 
@@ -12,6 +11,6 @@ public interface UserService {
 
 	Boolean existsByName(String nickname, Long id);
 
-	UserDto setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile);
+	UserDto setSignUp(Long userId, SignUpRequest signUpRequest, MultipartFile imageFile);
 
 }

--- a/server/src/main/java/com/ttukttak/oauth/service/UserService.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserService.java
@@ -12,6 +12,6 @@ public interface UserService {
 
 	Boolean existsByName(String nickname, Long id);
 
-	Boolean setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile);
+	UserDto setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile);
 
 }

--- a/server/src/main/java/com/ttukttak/oauth/service/UserService.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserService.java
@@ -10,7 +10,7 @@ public interface UserService {
 
 	UserDto getById(Long id);
 
-	Boolean existsByName(String nickname);
+	Boolean existsByName(String nickname, Long id);
 
 	Boolean setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile);
 

--- a/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
@@ -37,8 +37,8 @@ public class UserServiceImpl implements UserService {
 	}
 
 	@Override
-	public Boolean existsByName(String nickname) {
-		return userRepository.existsByNickname(nickname);
+	public Boolean existsByName(String nickname, Long id) {
+		return userRepository.existsByNicknameAndIdNot(nickname, id);
 	}
 
 	@Override

--- a/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
@@ -31,7 +31,7 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	public UserDto getById(Long id) {
-		User user = userRepository.getById(id);
+		User user = userRepository.findById(id).orElse(null);
 
 		return new UserDto(user);
 	}

--- a/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
@@ -43,7 +43,8 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	@Transactional
-	public Boolean setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile) {
+	public UserDto setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile) {
+		UserDto userDto = new UserDto();
 		try {
 			/*
 			 * 파일 업로드 (파일이 없는 경우 업로드 X)
@@ -72,10 +73,13 @@ public class UserServiceImpl implements UserService {
 			}
 
 			homeTownService.save(user, town);
+
+			userDto = new UserDto(userRepository.findById(user.getId()).orElse(null));
+
 		} catch (IOException e) {
-			return false;
+			return userDto;
 		}
-		return true;
+		return userDto;
 	}
 
 }

--- a/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
+++ b/server/src/main/java/com/ttukttak/oauth/service/UserServiceImpl.java
@@ -43,8 +43,9 @@ public class UserServiceImpl implements UserService {
 
 	@Override
 	@Transactional
-	public UserDto setSignUp(User user, SignUpRequest signUpRequest, MultipartFile imageFile) {
+	public UserDto setSignUp(Long userId, SignUpRequest signUpRequest, MultipartFile imageFile) {
 		UserDto userDto = new UserDto();
+		User user = userRepository.findById(userId).orElse(null);
 		try {
 			/*
 			 * 파일 업로드 (파일이 없는 경우 업로드 X)

--- a/server/src/main/java/com/ttukttak/oauth/token/TokenProvider.java
+++ b/server/src/main/java/com/ttukttak/oauth/token/TokenProvider.java
@@ -1,76 +1,90 @@
 package com.ttukttak.oauth.token;
 
+import java.util.Date;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import com.ttukttak.common.config.AppProperties;
 import com.ttukttak.oauth.entity.UserPrincipal;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.Date;
 
 @Service
 public class TokenProvider {
 
 	private static final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
 
-    private AppProperties appProperties;
-    @Getter
-    @Setter
-    private String jwtMsg;
+	private AppProperties appProperties;
+	@Getter
+	@Setter
+	private String jwtMsg;
 
-    public TokenProvider(AppProperties appProperties) {
-        this.appProperties = appProperties;
-    }
+	public TokenProvider(AppProperties appProperties) {
+		this.appProperties = appProperties;
+	}
 
-    public String createToken(Authentication authentication) {
-        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+	public String createToken(Authentication authentication) {
+		UserPrincipal userPrincipal = (UserPrincipal)authentication.getPrincipal();
 
-        Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + appProperties.getAuth().getTokenExpirationMsec());
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + appProperties.getAuth().getTokenExpirationMsec());
 
-        return Jwts.builder()
-                .setSubject(Long.toString(userPrincipal.getId()))
-                .setIssuedAt(new Date())
-                .setExpiration(expiryDate)
-                .signWith(SignatureAlgorithm.HS512, appProperties.getAuth().getTokenSecret())
-                .compact();
-    }
+		return Jwts.builder()
+			.setSubject(Long.toString(userPrincipal.getId()))
+			.setIssuedAt(new Date())
+			.setExpiration(expiryDate)
+			.signWith(SignatureAlgorithm.HS512, appProperties.getAuth().getTokenSecret())
+			.compact();
+	}
 
-    public Long getUserIdFromToken(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(appProperties.getAuth().getTokenSecret())
-                .parseClaimsJws(token)
-                .getBody();
+	public Long getUserIdFromToken(String token) {
+		Claims claims = Jwts.parser()
+			.setSigningKey(appProperties.getAuth().getTokenSecret())
+			.parseClaimsJws(token)
+			.getBody();
 
-        return Long.parseLong(claims.getSubject());
-    }
+		return Long.parseLong(claims.getSubject());
+	}
 
-    public boolean validateToken(String authToken) {
-        try {
-            Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
-            return true;
-        } catch (SignatureException ex) {
-            logger.error("유효하지 않은 JWT 서명");
-            this.jwtMsg = "유효하지 않은 JWT 서명";
-        } catch (MalformedJwtException ex) {
-            logger.error("유효하지 않은 JWT 토큰");
-            this.jwtMsg = "유효하지 않은 JWT 토큰";
-        } catch (ExpiredJwtException ex) {
-            logger.error("만료된 JWT 토큰");
-            this.jwtMsg = "만료된 JWT 토큰";
-        } catch (UnsupportedJwtException ex) {
-            logger.error("지원하지 않는 JWT 토큰");
-            this.jwtMsg = "지원하지 않는 JWT 토큰";
-        } catch (IllegalArgumentException ex) {
-            logger.error("비어있는 JWT");
-            this.jwtMsg = "비어있는 JWT";
-        }
-        return false;
-    }
+	public String getJwtFromHeader(String token) {
+		if (StringUtils.hasText(token) && token.startsWith("Bearer ")) {
+			return token.substring(7, token.length());
+		}
+		return null;
+	}
+
+	public boolean validateToken(String authToken) {
+		try {
+			Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+			return true;
+		} catch (SignatureException ex) {
+			logger.error("유효하지 않은 JWT 서명");
+			this.jwtMsg = "유효하지 않은 JWT 서명";
+		} catch (MalformedJwtException ex) {
+			logger.error("유효하지 않은 JWT 토큰");
+			this.jwtMsg = "유효하지 않은 JWT 토큰";
+		} catch (ExpiredJwtException ex) {
+			logger.error("만료된 JWT 토큰");
+			this.jwtMsg = "만료된 JWT 토큰";
+		} catch (UnsupportedJwtException ex) {
+			logger.error("지원하지 않는 JWT 토큰");
+			this.jwtMsg = "지원하지 않는 JWT 토큰";
+		} catch (IllegalArgumentException ex) {
+			logger.error("비어있는 JWT");
+			this.jwtMsg = "비어있는 JWT";
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
## 📕 제목

[BE] User 연관관계 추가 및 회원가입 반환값 수정

## 📗 작업 내용

- [x] User Entity HomeTown Entity 연관관계 추가
- [x] 유저 반환값 변경
- [x] 닉네임 체크 로직 수정 
--> 기존 : 같은 닉네임이 있는지 확인
--> 변경 : 자신을 제외한 나머지 데이터에 같은 닉네임이 있는지 확인
- [x] 회원가입 반환값 수정 [front에서 변경된 유저정보를 가지고 있어야함]
--> 기존 : 성공 유무
--> 변경 : 변경된 유저의 값 반환
- [x]  Request에 Swagger 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 위치기반 BOOK 정보를 가져올때 townid가 필요함!
- 위치기반 book 예상 시나리오.
>> 현재 검색하는 사용자의 townId 기준으로 인근 지역의 townId를 가져온다.
>> BOOK 조회할때 인근지역 townId로 where IN 조회
