### PR TITLE
[BE]: 대여내역 RentResponse roomId 추가

### DIFF
--- a/server/src/main/java/com/ttukttak/rent/dto/RentResponse.java
+++ b/server/src/main/java/com/ttukttak/rent/dto/RentResponse.java
@@ -14,6 +14,7 @@ import lombok.Data;
 @Data
 public class RentResponse {
 	private Long id;
+	private Long roomId;
 	private UserDto owner;
 	private UserDto lender;
 	private BookDto book;
@@ -30,6 +31,7 @@ public class RentResponse {
 
 		return RentResponse.builder()
 			.id(rent.getId())
+			.roomId(rent.getRoom().getId())
 			.owner(UserDto.from(rent.getOwner()))
 			.lender(UserDto.from(rent.getLender()))
 			.book(BookDto.from(rent.getBook()))
@@ -42,9 +44,10 @@ public class RentResponse {
 	}
 
 	@Builder
-	public RentResponse(Long id, UserDto owner, UserDto lender, BookDto book, LocalDate beginDate,
+	public RentResponse(Long id, Long roomId, UserDto owner, UserDto lender, BookDto book, LocalDate beginDate,
 		LocalDate endDate, LocalDate returnDate, List<ExtendResponse> extendList, Rent.RentStatus status) {
 		this.id = id;
+		this.roomId = roomId;
 		this.owner = owner;
 		this.lender = lender;
 		this.book = book;


### PR DESCRIPTION
## 📕 [BE]: 대여내역 RentResponse roomId 추가

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 대여내역에서 바로 채팅방 정보를 조회할 수 있도록 roomId 추가


