### PR TITLE
[BE]프로필 이미지 수정시 NULL 체크 추가

### DIFF
--- a/server/src/main/java/com/ttukttak/common/StorageUploader.java
+++ b/server/src/main/java/com/ttukttak/common/StorageUploader.java
@@ -42,10 +42,11 @@ public class StorageUploader {
 	public void removeOldFile(String imageUrl) {
 		try {
 			String storageUrl = "https://" + bucket + ".kr.object.ncloudstorage.com/";
-			if (imageUrl.indexOf(storageUrl) > -1) {
+			if (imageUrl == null) {
+				log.info("기존 이미지가 없습니다.");
+			} else if (imageUrl.indexOf(storageUrl) > -1) {
 				String objectName = imageUrl.replace(storageUrl, "");
 				amazonS3Client.deleteObject(bucket, objectName);
-				System.out.format("bucket %s Object %s has been deleted.\n", bucket, objectName);
 			} else {
 				log.info("ncloudsotrage에 있는 파일이 아닙니다.");
 			}


### PR DESCRIPTION
#163

## 📕 제목

PR 제목
[BE]프로필 이미지 수정시 NULL 체크 추가

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] #163 > StorageUploader 기존 이미지 제거 함수 null 체크 추가

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 이슈 발생 상황 : 소셜 회원가입 시 프로필 항목을 동의하지 않는 경우에는 image_url의 값이 null -> 기존 이미지 storage 삭제 함수 실행시에 기존이미지가 null이기 때문에 NullPoint 에러 발생.
